### PR TITLE
fix: adjust bank summary calculations to include charges for transact…

### DIFF
--- a/apps/nest-backend/src/user/user.controller.ts
+++ b/apps/nest-backend/src/user/user.controller.ts
@@ -191,13 +191,22 @@ export class UserController {
 
       bank.incExpRecords?.forEach((record) => {
         if (record.type === IncExpRecordType.EXPENSE)
-          bankSummary[bank.name].value -= record.amount;
+          bankSummary[bank.name].value -= record.amount + (record.charge ?? 0);
         else if (record.type === IncExpRecordType.INCOME)
           bankSummary[bank.name].value += record.amount;
       });
 
       bank.bankRecords?.forEach((bankRecord) => {
-        bankSummary[bank.name].value += Number(bankRecord.amount);
+        if (bankRecord.type === 'DEPOSIT' || bankRecord.type === 'TRANSFERIN') {
+          bankSummary[bank.name].value += Number(bankRecord.amount);
+          bankSummary[bank.name].value -= bankRecord.charge ?? 0;
+        } else if (
+          bankRecord.type === 'WITHDRAW' ||
+          bankRecord.type === 'TRANSFEROUT'
+        ) {
+          bankSummary[bank.name].value -= Number(bankRecord.amount);
+          bankSummary[bank.name].value -= bankRecord.charge ?? 0;
+        }
       });
 
       bank.stockBuyRecords?.forEach((stockBuyRecord) => {
@@ -289,19 +298,31 @@ export class UserController {
       bank.bankRecords?.forEach((bankRecord) => {
         const date = moment(bankRecord.date);
         const value = Number(bankRecord.amount);
-        addValueToYearAndWeek(date.year(), date.week(), value * bank.currency.exchangeRate);
+        addValueToYearAndWeek(
+          date.year(),
+          date.week(),
+          value * bank.currency.exchangeRate,
+        );
       });
 
       bank.stockBuyRecords?.forEach((stockBuyRecord) => {
         const date = moment(stockBuyRecord.date);
         const value = -Number(stockBuyRecord.amount);
-        addValueToYearAndWeek(date.year(), date.week(), value * bank.currency.exchangeRate);
+        addValueToYearAndWeek(
+          date.year(),
+          date.week(),
+          value * bank.currency.exchangeRate,
+        );
       });
 
       bank.stockBundleSellRecords?.forEach((stockBundleSellRecord) => {
         const date = moment(stockBundleSellRecord.date);
         const value = Number(stockBundleSellRecord.amount);
-        addValueToYearAndWeek(date.year(), date.week(), value * bank.currency.exchangeRate);
+        addValueToYearAndWeek(
+          date.year(),
+          date.week(),
+          value * bank.currency.exchangeRate,
+        );
       });
     });
 

--- a/apps/next-frontend/app/bank/dashboard/page.tsx
+++ b/apps/next-frontend/app/bank/dashboard/page.tsx
@@ -97,9 +97,9 @@ const DashboardBank = () => {
           bankData[bankId].income += record.amount;
           break;
         case IncExpRecordType.EXPENSE:
-          bankData[bankId].total -= record.amount;
+          bankData[bankId].total -= record.amount + (record.charge ?? 0);
           bankData[bankId].expense += record.amount;
-          bankData[bankId].charge += record.charge as number;
+          bankData[bankId].charge += record.charge ?? 0;
           break;
       }
     });


### PR DESCRIPTION
### PR Description  

#### Problem Summary:  
1. **Incorrect Bank Summary Calculation:**  
   The bank summary value was miscalculated because record types were not correctly factored in.  
   
2. **Dashboard Total Value Issue:**  
   The bank dashboard did not account for charge fees, leading to inaccurate total values.  

#### Solutions Implemented:  
- Fixed the bank record calculations by correctly adding or subtracting values based on the record type.  
- Updated the dashboard logic to include charge fees in the total bank value calculation.  

This PR ensures accurate financial reporting on both the bank summary and dashboard pages.
